### PR TITLE
Experimental/autosave freeze fix

### DIFF
--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -650,7 +650,7 @@
                 {
                     [self setFileType:typeName];
                     [self setFileURL:url];
-                    [self setAutosavedContentsFileURL:url];
+                    [self setAutosavedContentsFileURL:nil];
                     [self updateChangeCount:NSChangeAutosaved];
 
                     NSDate* fileDate = nil;

--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -648,16 +648,17 @@
                 NSError* fileWriteError = nil;
                 if ([self writeSafelyToURL:url ofType:typeName forSaveOperation:saveOperation error:&fileWriteError])
                 {
+                    [self setFileType:typeName];
+                    [self setFileURL:url];
+                    [self setAutosavedContentsFileURL:url];
+                    [self updateChangeCount:NSChangeAutosaved];
+
                     NSDate* fileDate = nil;
                     [url getResourceValue:&fileDate forKey:NSURLAttributeModificationDateKey error:nil];
                     if (!fileDate) {
                         fileDate = [NSDate date];
                     }
                     [self setFileModificationDate:fileDate];
-                    [self setFileType:typeName];
-                    [self setFileURL:url];
-                    [self setAutosavedContentsFileURL:url];
-                    [self updateChangeCount:NSChangeAutosaved];
                     saveCompletionHandler(nil);
                 }
                 else

--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -20,6 +20,7 @@
 
 #import "BSManagedDocument.h"
 
+static NSString* BSStringFromSaveOperationType(NSSaveOperationType type);
 
 @interface BSManagedDocument ()
 @property(nonatomic, copy) NSURL *autosavedContentsTempDirectoryURL;
@@ -637,7 +638,9 @@
                 });
             }
         };
-        
+#ifdef DDLogDebug
+        DDLogDebug(@"Starting saving work with operation: %@",BSStringFromSaveOperationType(saveOperation));
+#endif
         // Kick off async saving work
         if (saveOperation == NSAutosaveInPlaceOperation)
         {
@@ -1155,5 +1158,30 @@ originalContentsURL:(NSURL *)originalContentsURL
 }
 
 @end
+
+
+static NSString* BSStringFromSaveOperationType(NSSaveOperationType type)
+{
+    switch (type) {
+        case NSSaveOperation:
+            return @"NSSaveOperation";
+        case NSSaveAsOperation:
+            return @"NSSaveAsOperation";
+        case NSSaveToOperation:
+            return @"NSSaveToOperation";
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7
+        case NSAutosaveInPlaceOperation:
+            return @"NSAutosaveInPlaceOperation";
+        case NSAutosaveElsewhereOperation:
+            return @"NSAutosaveElsewhereOperation";
+#endif
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_8
+        case NSAutosaveAsOperation:
+            return @"NSAutosaveAsOperation";
+#endif
+        default:
+            return @"";
+    }
+}
 
 

--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -1213,7 +1213,7 @@ static NSString* BSStringFromSaveOperationType(NSSaveOperationType type)
             return @"NSAutosaveAsOperation";
 #endif
         default:
-            return @"";
+            return [NSString stringWithFormat:@"UnknownSaveOperationType:%d",(int)type];
     }
 }
 

--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -582,9 +582,7 @@
         [_contents retain];
 #endif
         
-        
-        // Kick off async saving work
-        [super saveToURL:url ofType:typeName forSaveOperation:saveOperation completionHandler:^(NSError *error) {
+        void(^saveCompletionHandler)(NSError*) =^(NSError *error) {
             
             // If the save failed, it might be an error the user can recover from.
 			// e.g. the dreaded "file modified by another application"
@@ -628,7 +626,48 @@
 			// And can finally declare we're done
             fileAccessCompletionHandler();
             if (completionHandler) completionHandler(error);
-        }];
+        };
+        
+        // Kick off async saving work
+        if (saveOperation == NSAutosaveInPlaceOperation)
+        {
+            // NSDocument's implementation for AutosaveInPlace seems to be broken and freezes on NSFileCoordinator.
+            // at [NSDocument _fileCoordinator:coordinateReadingContentsAndWritingItemAtURL:byAccessor:] to be precise
+            // thus we do our own just for this.
+            void(^autosaveInPlaceImplementation)() = ^{
+                NSError* fileWriteError = nil;
+                if ([self writeSafelyToURL:url ofType:typeName forSaveOperation:saveOperation error:&fileWriteError])
+                {
+                    NSDate* fileDate = nil;
+                    [url getResourceValue:&fileDate forKey:NSURLAttributeModificationDateKey error:nil];
+                    if (!fileDate) {
+                        fileDate = [NSDate date];
+                    }
+                    [self setFileModificationDate:fileDate];
+                    [self setFileType:typeName];
+                    [self setFileURL:url];
+                    [self setAutosavedContentsFileURL:url];
+                    [self updateChangeCount:NSChangeAutosaved];
+                    saveCompletionHandler(nil);
+                }
+                else
+                {
+                    saveCompletionHandler(fileWriteError);
+                }
+            };
+            if ([self canAsynchronouslyWriteToURL:url ofType:typeName forSaveOperation:saveOperation])
+            {
+                [[self presentedItemOperationQueue] addOperationWithBlock:autosaveInPlaceImplementation];
+            }
+            else
+            {
+                autosaveInPlaceImplementation();
+            }
+        }
+        else
+        {
+            [super saveToURL:url ofType:typeName forSaveOperation:saveOperation completionHandler:saveCompletionHandler];
+        }
     }];
 }
 

--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -574,7 +574,12 @@
         {
             // The docs say "be sure to invoke super", but by my understanding it's fine not to if it's because of a failure, as the filesystem hasn't been touched yet.
             fileAccessCompletionHandler();
-            if (completionHandler) completionHandler(error);
+            if (completionHandler)
+            {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    completionHandler(error);
+                });
+            }
             return;
         }
         
@@ -625,7 +630,12 @@
 			
 			// And can finally declare we're done
             fileAccessCompletionHandler();
-            if (completionHandler) completionHandler(error);
+            if (completionHandler)
+            {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    completionHandler(error);
+                });
+            }
         };
         
         // Kick off async saving work

--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -700,6 +700,26 @@ static NSString* BSStringFromSaveOperationType(NSSaveOperationType type);
         }
         else
         {
+            if (saveOperation == NSAutosaveElsewhereOperation) {
+                NSURL* originalAutosavedContentsFileURL = self.autosavedContentsFileURL;
+                NSURL* autosavedContentsFileURL = originalAutosavedContentsFileURL;
+                int counter = 0;
+                // Make sure that we have a non-pre-existing file as the autosave contents.
+                while ([autosavedContentsFileURL checkResourceIsReachableAndReturnError:nil]) {
+                    counter++;
+                    NSString* path = [[autosavedContentsFileURL path] stringByStandardizingPath];
+                    NSString* file = [path lastPathComponent];
+                    NSString* dir = [path stringByDeletingLastPathComponent];
+                    NSString* baseName = [file stringByDeletingPathExtension];
+                    NSString* extension = [file pathExtension];
+                    NSString* updatedName = [NSString stringWithFormat:@"%@ %d.%@",baseName,counter,extension];
+                    autosavedContentsFileURL = [NSURL fileURLWithPath:[dir stringByAppendingPathComponent:updatedName]];
+                }
+                [self setAutosavedContentsFileURL:autosavedContentsFileURL];
+#ifdef DDLogDebug
+                DDLogDebug(@"Autosave elsewhere. autosavedContentsFileURL: %@ originalAutosavedContentsFileURL: %@",autosavedContentsFileURL,originalAutosavedContentsFileURL);
+#endif
+            }
             [super saveToURL:url ofType:typeName forSaveOperation:saveOperation completionHandler:saveCompletionHandler];
         }
     }];


### PR DESCRIPTION
This fixes the freezing issue found in [#24](https://github.com/karelia/BSManagedDocument/issues/24). Apparently `NSDocument` freezes during in-place autosave on file coordination, thus the solution is to have our own in-place autosave implementation that skips it. Since the persistent store isn't expected to move while being open anyway, it's likely safe to skip calling `NSFileCoordinator` during autosave.

I've incorporated this in my application and sent out a beta release and seems stable. Furthermore I'm making that beta live now (cross fingers ;-) )
