### PR TITLE
Ensure that the persistent store is added in the appropriate dispatch queue to avoid deadlocks.

### DIFF
--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -140,17 +140,33 @@
                                      storeOptions:(NSDictionary *)storeOptions
                                             error:(NSError **)error
 {
-	NSPersistentStoreCoordinator *storeCoordinator = [[self managedObjectContext] persistentStoreCoordinator];
-	
-    _store = [storeCoordinator addPersistentStoreWithType:[self persistentStoreTypeForFileType:fileType]
-                                            configuration:configuration
-                                                      URL:storeURL
-                                                  options:storeOptions
-                                                    error:error];
+	NSManagedObjectContext *managedObjectContext = [self managedObjectContext];
+
+	if ([managedObjectContext respondsToSelector:@selector(parentContext)]) {
+		[managedObjectContext performBlockAndWait:^{
+			NSPersistentStoreCoordinator *storeCoordinator = [managedObjectContext persistentStoreCoordinator];
+
+			_store = [storeCoordinator addPersistentStoreWithType:[self persistentStoreTypeForFileType:fileType]
+													configuration:configuration
+															  URL:storeURL
+														  options:storeOptions
+															error:error];
+		}];
+	}
+	else {
+		NSPersistentStoreCoordinator *storeCoordinator = [managedObjectContext persistentStoreCoordinator];
+
+		_store = [storeCoordinator addPersistentStoreWithType:[self persistentStoreTypeForFileType:fileType]
+												configuration:configuration
+														  URL:storeURL
+													  options:storeOptions
+														error:error];
+	}
+
 #if ! __has_feature(objc_arc)
-    [_store retain];
+	[_store retain];
 #endif
-    
+
 	return (_store != nil);
 }
 


### PR DESCRIPTION
...eue to avoid deadlocks.

This is necessary because adding a persistent store emits notifications that can result in bound controllers re-fetching their content in the notification thread, which isn't necessarily the main thread.  This may conflict with any user activity simultaneously occurring on the MOC.
